### PR TITLE
Add Nano RP2040 Connect to CI compilation matrix

### DIFF
--- a/.github/workflows/compile-examples.yml
+++ b/.github/workflows/compile-examples.yml
@@ -41,10 +41,16 @@ jobs:
               - name: Arduino_HTS221
               - name: Arduino_LPS22HB
               - name: Arduino_LSM9DS1
-              - name: Arduino_LSM6DSOX
               - name: ArduinoBLE
               - name: Arduino_CMSIS-DSP
             sketch-paths: examples/Nano33BLESenseFirmware
+          - fqbn: arduino:mbed_nano:nanorp2040connect
+            platforms: |
+              - name: arduino:mbed_nano
+            libraries: |
+              - name: Arduino_LSM6DSOX
+              - name: ArduinoBLE
+            sketch-paths: examples/RP2040ConnectFirmware
           - fqbn: arduino:samd:mkrwifi1010
             platforms: |
               - name: arduino:samd


### PR DESCRIPTION
Since the examples are board-specific, the "Compile Examples" CI workflow had to be configured to compile specific sketches for specific boards, as opposed to a more simple workflow that would compile all sketches in the `examples` folder for all boards in the matrix.

A sketch written for the Nano RP2040 Connect has been added to the repository, so the matrix must be expanded to compile that sketch for that board.